### PR TITLE
allow -n for --namespace alias, like kubectl; already existed for kwt net svc

### DIFF
--- a/docs/cmd/kwt_net_clean-up.md
+++ b/docs/cmd/kwt_net_clean-up.md
@@ -15,7 +15,7 @@ kwt net clean-up [flags]
 ```
       --debug              Set logging level to debug
   -h, --help               help for clean-up
-      --namespace string   Namespace to use to manage networking pod (default "default")
+  -n, --namespace string   Namespace to use to manage networking pod (default "default")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/kwt_net_start.md
+++ b/docs/cmd/kwt_net_start.md
@@ -37,7 +37,7 @@ kwt net start [flags]
       --dns-mdns                 Start MDNS server (default true)
   -r, --dns-recursor strings     Recursor (can be specified multiple times)
   -h, --help                     help for start
-      --namespace string         Namespace to use to manage networking pod (default "default")
+  -n, --namespace string         Namespace to use to manage networking pod (default "default")
       --remote-ip strings        Additional IP to include for subnet guessing (can be specified multiple times)
       --ssh-host string          SSH server address for forwarding connections (includes port)
       --ssh-private-key string   Private key for connecting to SSH server (PEM format)

--- a/pkg/kwt/cmd/net/namespace_flags.go
+++ b/pkg/kwt/cmd/net/namespace_flags.go
@@ -9,5 +9,5 @@ type NamespaceFlags struct {
 }
 
 func (s *NamespaceFlags) Set(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&s.Name, "namespace", "default", "Namespace to use to manage networking pod")
+	cmd.Flags().StringVarP(&s.Name, "namespace", "n", "default", "Namespace to use to manage networking pod")
 }


### PR DESCRIPTION
/cc @cppforlife 