### PR TITLE
in CheckPrereqs pass -n (numeric) to iptables

### DIFF
--- a/pkg/kwt/net/forwarder/iptables.go
+++ b/pkg/kwt/net/forwarder/iptables.go
@@ -48,7 +48,7 @@ func NewIptables(opts IptablesOpts, exec CmdExecutor, logger Logger) Iptables {
 }
 
 func (i Iptables) CheckPrereqs() error {
-	out, err := i.runCmd([]string{"-L", "-t", "nat"})
+	out, err := i.runCmd([]string{"-L", "-t", "nat", "-n"})
 	if err != nil {
 		return fmt.Errorf("Checking 'iptables' can run successfully: %s (output: %s)", err, out)
 	}


### PR DESCRIPTION
Sometimes reverse dns lookups are slow so asking iptables to return numeric addresses speeds this up